### PR TITLE
Fixes for DADIS sync workflow

### DIFF
--- a/src/ontology/vbo.Makefile
+++ b/src/ontology/vbo.Makefile
@@ -11,8 +11,6 @@ DOGBREEDS_TEMPLATE="https://docs.google.com/spreadsheets/d/e/2PACX-1vSuwLXikgq08
 BREEDSTATUS_TEMPLATE="https://docs.google.com/spreadsheets/d/e/2PACX-1vTk1AOht1rOoyXExlZu9KzCOtfIOoTGBxkVmJ6dvE9wuQ1Q7LfwMA93vF0yRPpG7GMq03mKFdV74YnG/pub?gid=1650821837&single=true&output=tsv"
 HIGHLEVELCLASS_TEMPLATE="https://docs.google.com/spreadsheets/d/e/2PACX-1vRpjOwuI9e1Imkdp40nPTw5cNKFjdpV9fHSHDIfcdXfod41sSogjFhWfas8Cjdpfa4lEVR0GyYxFDrE/pub?gid=2041564448&single=true&output=tsv"
 
-.PHONY: dadis-transboundary-sync
-.PHONY: dadis-local-sync
 
 
 sync_google_sheets:
@@ -69,19 +67,22 @@ $(IMPORTDIR)/wikidata_import.owl: $(TMPDIR)/wikidata_labels.ttl
 .PHONY: wikidata
 wikidata: $(IMPORTDIR)/wikidata_import.owl
 
+.PHONY: dadis-transboundary-sync
+.PHONY: dadis-local-sync
+
 ifeq ($(DADIS_API_KEY),)
-$(COMPONENTSDIR)/dadisbreedcountry.tsv:
+dadis-local-sync:
 	@echo "WARNING: DADIS_API_KEY not set, skipping dadisbreedcountry.tsv"
 
-$(COMPONENTSDIR)/dadistransbound.tsv:
+dadis-transboundary-sync:
 	@echo "WARNING: DADIS_API_KEY not set, skipping dadistransbound.tsv"
 
 else
-$(COMPONENTSDIR)/dadisbreedcountry.tsv:
+dadis-local-sync:
 	pip install pydantic>=2.5.3 pandas>=2.1.4
 	python ../scripts/find_dadis_local_ids.py --input_filename ./components/dadisbreedcountry.tsv --output_filename ./components/dadisbreedcountry.tsv
 
-$(COMPONENTSDIR)/dadistransbound.tsv:
+dadis-transboundary-sync:
 	pip install pydantic>=2.5.3 pandas>=2.1.4
 	python ../scripts/find_dadis_transboundary_ids.py --input_filename ./components/dadistransbound.tsv --output_filename ./components/dadistransbound.tsv
 

--- a/src/scripts/find_dadis_local_ids.py
+++ b/src/scripts/find_dadis_local_ids.py
@@ -2,6 +2,8 @@ import argparse
 import csv
 import logging
 import os
+import shutil
+from tempfile import NamedTemporaryFile
 from typing import Optional, TextIO
 
 import pandas as pd
@@ -29,19 +31,25 @@ def full_local_match_workflow(
     logger.info(f"Matching to DADIS data")
     matched_breeds = match_vbo_breeds(vbo_data=vbo_data, client=client)
 
-    logger.info(f"Writing output file to {output_filename}:")
-    output_file = create_output_tsv(
-        input_filename=input_filename,
-        output_filename=output_filename,
-        extra_cols=[
-            "dadis_breed_id",
-            "dadis_transboundary_id",
-            "dadis_update_date",
-        ],
-    )
-    matched_breeds.to_csv(output_file, sep="\t", index=False, header=False)
-    output_file.close()
-    logger.info("Output written.")
+    # We need to create a temporary file for the output, in case we're writing
+    #   to the same filename as the input: we don't want
+    #   to overwrite/clear the input file until we can read the header from it
+    logger.info(f"Creating temporary output TSV:")
+    with NamedTemporaryFile(mode="w", delete=False) as temp_out:
+        write_tsv_header(
+            input_filename=input_filename,
+            output_file=temp_out,
+            extra_cols=[
+                "dadis_breed_id",
+                "dadis_transboundary_id",
+                "dadis_update_date",
+            ],
+        )
+        matched_breeds.to_csv(temp_out, sep="\t", index=False, header=False)
+        temp_out.close()
+        logger.info("Output written to temp file.")
+        shutil.copy2(src=temp_out.name, dst=output_filename)
+        logger.info(f"Copied to {output_filename}")
 
     if dadis_match_filename is not None:
         logger.info("Finding unmatched DADIS entries")
@@ -128,15 +136,13 @@ def find_unmatched_dadis(vbo_output: pd.DataFrame, client: DadisClient) -> pd.Da
     return dadis_unmatched
 
 
-def create_output_tsv(
-    input_filename: str, output_filename: str, extra_cols: list[str] = None
-) -> TextIO:
+def write_tsv_header(
+    input_filename: str, output_file: TextIO, extra_cols: list[str] = None
+):
     """
-    Copy the 2 header lines from the input file to the output file. Return
-    a file object for the output file, so pandas can write the rest of the file
+    Copy the two header lines from the input file to output_file, adding the columns in extra_cols
     """
-    file_out = open(output_filename, "w")
-    csv_out = csv.writer(file_out, dialect="excel-tab")
+    csv_out = csv.writer(output_file, dialect="excel-tab")
     with open(input_filename) as file_in:
         csv_in = csv.reader(file_in, dialect="excel-tab")
         for index, line in enumerate(range(2)):
@@ -147,7 +153,6 @@ def create_output_tsv(
                 if index == 1:
                     header += ["" for i in range(len(extra_cols))]
             csv_out.writerow(header)
-    return file_out
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Hi @matentzn ,

This PR contains fixes for a couple of issues with the DADIS sync workflow:

* The make jobs did not seem to work since they were using an existing filename, so make was reporting "nothing to be done". I have not worked much with `make` so you may need to check that my updated version makes sense
* The scripts had issues when trying to read from and write to the same filename, since they need to copy the header from the input file. I've updated it so we create a temporary output file first, then copy to the final destination