### PR TITLE
Add synonym type superproperty for most_common_name

### DIFF
--- a/src/ontology/vbo-edit.owl
+++ b/src/ontology/vbo-edit.owl
@@ -79,6 +79,7 @@ SubAnnotationPropertyOf(<http://purl.obolibrary.org/obo/vbo#local_breed> <http:/
 # Annotation Property: <http://purl.obolibrary.org/obo/vbo#most_common_name> (most common name)
 
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/vbo#most_common_name> "most common name")
+SubAnnotationPropertyOf(<http://purl.obolibrary.org/obo/vbo#most_common_name> <http://www.geneontology.org/formats/oboInOwl#SynonymTypeProperty>)
 
 # Annotation Property: <http://purl.obolibrary.org/obo/vbo#national_breed_population> (national breed population)
 


### PR DESCRIPTION
Closes #207 

This PR makes sure that the `most_common_name` is exported as a synonym type definition in OBO by adding a a parent annotation to http://www.geneontology.org/formats/oboInOwl#SynonymTypeProperty

The OBO export from the edit file now looks like this, so I'm assuming that duing build that this will get propagated properly

```
format-version: 1.2
subsetdef: local_breed "refers to a breed reported in single country, as defined in DAD-IS (https://www.fao.org/dad-is)"
subsetdef: national_breed_population "refers to the instance of the transboundary breed in a particular country, as defined in DAD-IS (https://www.fao.org/dad-is)"
subsetdef: transboundary "refers to a breed reported in several different countries, as defined in DAD-IS (https://www.fao.org/dad-is)"
synonymtypedef: most_common_name "most common name"
idspace: dce http://purl.org/dc/elements/1.1/ 
idspace: dcterms http://purl.org/dc/terms/ 
...
```